### PR TITLE
[Fix] 캐릭터 이동 조이스틱 자연스럽게 수정

### DIFF
--- a/TtouchIsland/Sources/ControllerInput/ControllerInputSystem.swift
+++ b/TtouchIsland/Sources/ControllerInput/ControllerInputSystem.swift
@@ -17,67 +17,69 @@ import SwiftUI
 public struct ControllerInputSystem: System, Sendable {
     @MainActor static var jumpPressed = false
     @MainActor static var circlePressed = false
-//    nonisolated(unsafe) static var controller: GCController?
+    //    nonisolated(unsafe) static var controller: GCController?
 
     public init(scene _: RealityKit.Scene) {
-//        NotificationCenter.default.addObserver(
-//            forName: NSNotification.Name.GCControllerDidConnect,
-//            object: nil, queue: nil,
-//            using: didConnectController)
-//        NotificationCenter.default.addObserver(
-//            forName: NSNotification.Name.GCControllerDidDisconnect,
-//            object: nil, queue: nil,
-//            using: didDisconnectController)
+        //        NotificationCenter.default.addObserver(
+        //            forName: NSNotification.Name.GCControllerDidConnect,
+        //            object: nil, queue: nil,
+        //            using: didConnectController)
+        //        NotificationCenter.default.addObserver(
+        //            forName: NSNotification.Name.GCControllerDidDisconnect,
+        //            object: nil, queue: nil,
+        //            using: didDisconnectController)
         GCController.startWirelessControllerDiscovery()
     }
 
-//    func didConnectController(_ notification: Notification) {
-//        Self.controller = notification.object as? GCController
-//        if let controller = Self.controller {
-//            print("◦ connected")
-//
-//            if let controller = controller.extendedGamepad {
-//                controller.buttonX.valueChangedHandler = { _, _, isPressed in
-//                    Task { @MainActor in
-//                        ControllerInputSystem.circleButtonChanged(isPressed)
-//                    }
-//                }
-//            } else if let controller = controller.microGamepad {
-//                controller.buttonX.valueChangedHandler = { _, _, isPressed in
-//                    Task { @MainActor in
-//                        ControllerInputSystem.circleButtonChanged(isPressed)
-//                    }
-//                }
-//            }
-//
-//            // Register the haptic utility.
-//            HapticUtility.initHapticsFor(controller: controller)
-//        }
-//    }
-//
-//    func didDisconnectController(_ notification: Notification) {
-//        print("◦ disconnected")
-//        // Unregister the haptic utility.
-//        if let controller = notification.object as? GCController {
-//            HapticUtility.deinitHapticsFor(controller: controller)
-//        }
-//
-//        Self.controller = nil
-//    }
+    //    func didConnectController(_ notification: Notification) {
+    //        Self.controller = notification.object as? GCController
+    //        if let controller = Self.controller {
+    //            print("◦ connected")
+    //
+    //            if let controller = controller.extendedGamepad {
+    //                controller.buttonX.valueChangedHandler = { _, _, isPressed in
+    //                    Task { @MainActor in
+    //                        ControllerInputSystem.circleButtonChanged(isPressed)
+    //                    }
+    //                }
+    //            } else if let controller = controller.microGamepad {
+    //                controller.buttonX.valueChangedHandler = { _, _, isPressed in
+    //                    Task { @MainActor in
+    //                        ControllerInputSystem.circleButtonChanged(isPressed)
+    //                    }
+    //                }
+    //            }
+    //
+    //            // Register the haptic utility.
+    //            HapticUtility.initHapticsFor(controller: controller)
+    //        }
+    //    }
+    //
+    //    func didDisconnectController(_ notification: Notification) {
+    //        print("◦ disconnected")
+    //        // Unregister the haptic utility.
+    //        if let controller = notification.object as? GCController {
+    //            HapticUtility.deinitHapticsFor(controller: controller)
+    //        }
+    //
+    //        Self.controller = nil
+    //    }
 
-//    @MainActor static func jumpButtonChanged(_ isPressed: Bool) {
-//        if isPressed {
-//            ControllerInputSystem.jumpPressed = true
-//        }
-//    }
-//
-//    @MainActor static func circleButtonChanged(_ isPressed: Bool) {
-//        if isPressed {
-//            ControllerInputSystem.circlePressed = true
-//        }
-//    }
+    //    @MainActor static func jumpButtonChanged(_ isPressed: Bool) {
+    //        if isPressed {
+    //            ControllerInputSystem.jumpPressed = true
+    //        }
+    //    }
+    //
+    //    @MainActor static func circleButtonChanged(_ isPressed: Bool) {
+    //        if isPressed {
+    //            ControllerInputSystem.circlePressed = true
+    //        }
+    //    }
 
     public mutating func update(context: SceneUpdateContext) {
+        guard let controller = GCController.current else { return }
+
         let cameraEntities = context.entities(
             matching: EntityQuery(where: .has(ControllerInputReceiver.self)),
             updatingSystemWhen: .rendering
@@ -85,36 +87,27 @@ public struct ControllerInputSystem: System, Sendable {
         var entitiesEmpty = true
 
         for entity in cameraEntities {
-            guard var inputReceiverComponent = entity.components[ControllerInputReceiver.self]
+            guard
+                var inputReceiverComponent = entity.components[
+                    ControllerInputReceiver.self
+                ]
             else { continue }
             entitiesEmpty = false
 
-            // An extended game controller.
-//            if let gamepad = controller.extendedGamepad {
-//                inputReceiverComponent.leftJoystick = [
-//                    gamepad.leftThumbstick.xAxis.value, gamepad.leftThumbstick.yAxis.value]
-            ////                inputReceiverComponent.rightJoystick = [
-            ////                    gamepad.rightThumbstick.xAxis.value, gamepad.rightThumbstick.yAxis.value]
-//
-//                if gamepad.buttonA.isPressed != inputReceiverComponent.jumpPressed {
-//                    inputReceiverComponent.jumpPressed = gamepad.buttonA.isPressed
-//                }
-//                if Self.circlePressed {
-//                    inputReceiverComponent.attackReady = true
-//                }
-//            } else if let gamepad = controller.microGamepad {
-//                // A Siri remote.
-//                inputReceiverComponent.leftJoystick = [
-//                    gamepad.dpad.xAxis.value, gamepad.dpad.yAxis.value]
-//
-//                if gamepad.buttonA.isPressed != inputReceiverComponent.jumpPressed {
-//                    inputReceiverComponent.jumpPressed = gamepad.buttonA.isPressed
-//                }
-//                if Self.circlePressed {
-//                    inputReceiverComponent.attackReady = true
-//                }
-//            }
-
+            // GCController의 extendedGamepad에서 조이스틱 축 값을 매 프레임마다 읽어와서 leftJoystick에 저장
+            if let gamepad = controller.extendedGamepad {
+                inputReceiverComponent.leftJoystick = [
+                    gamepad.leftThumbstick.xAxis.value,
+                    gamepad.leftThumbstick.yAxis.value,
+                ]
+            }
+            //                if gamepad.buttonA.isPressed != inputReceiverComponent.jumpPressed {
+            //                    inputReceiverComponent.jumpPressed = gamepad.buttonA.isPressed
+            //                }
+            //                if Self.circlePressed {
+            //                    inputReceiverComponent.attackReady = true
+            //                }
+            //            }
             inputReceiverComponent.update(for: entity)
             entity.components.set(inputReceiverComponent)
         }


### PR DESCRIPTION
### 📕 Issue Number

Close #32 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 캐릭터 이동 물리 엔진 자연스럽게 수정하기


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

```swift
            if let gamepad = controller.extendedGamepad {
                inputReceiverComponent.leftJoystick = [
                    gamepad.leftThumbstick.xAxis.value,
                    gamepad.leftThumbstick.yAxis.value,
                ]
            }
``` 
- GCController의 extendedGamepad(GameController)에서 조이스틱 축 값을 매 프레임마다 읽어와서 leftJoystick에 저장하는 코드를 살렸습니다
- https://developer.apple.com/documentation/gamecontroller
- https://developer.apple.com/documentation/gamecontroller/gccontroller

### 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

- 스크린 샷


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>


<br/><br/>
