### PR TITLE
[Feat] 땃쥐 로티 애니메이션 정상화

### DIFF
--- a/TtouchIsland/Sources/Game/GameView+Item.swift
+++ b/TtouchIsland/Sources/Game/GameView+Item.swift
@@ -114,8 +114,10 @@ extension GameView {
     func handleNewspaperItem(item: Entity, camera: Entity) {
         do {
             if manager.isFocusedOnItem {
+                manager.updateStatus(to: .common)
                 try returnToPlayerView(camera: camera)
             } else {
+                manager.updateStatus(to: .read)
                 try closeupNewspaper(newspaper: item, camera: camera)
             }
         } catch {

--- a/TtouchIsland/Sources/Game/GameView.swift
+++ b/TtouchIsland/Sources/Game/GameView.swift
@@ -50,7 +50,7 @@ struct GameView: View {
                 }
 
                 PlatformerThumbControl(
-                    appModel: manager,
+                    manager: manager,
                     character: character,
                     itemAction: { item, camera in
                         if item.components[ItemComponent.self]?.type
@@ -62,6 +62,10 @@ struct GameView: View {
                         if manager.visibleItems.count == 1 {
                             if item.components[ItemComponent.self]?.type == .backpack {
                                 print("🎒")
+
+                                // 땃쥐 행복해하는 로티 애니메이션 플레이
+                                manager.updateStatus(to: .getItem)
+
                                 manager.visibleItems[0].isSolid = true
                                 manager.setAllItemsAvailable()
                                 item.removeFromParent()
@@ -71,6 +75,10 @@ struct GameView: View {
                         if manager.visibleItems.count > 1 {
                             if item.components[ItemComponent.self]?.type == .cheese {
                                 print("🧀")
+
+                                // 땃쥐 행복해하는 로티 애니메이션 플레이
+                                manager.updateStatus(to: .getItem)
+
                                 Task { await setCharacterScaleUp() }
                                 manager.visibleItems[1].isSolid = true
                                 item.removeFromParent()
@@ -78,12 +86,20 @@ struct GameView: View {
                             }
                             if item.components[ItemComponent.self]?.type == .bottle {
                                 print("🍶")
+
+                                // 땃쥐 행복해하는 로티 애니메이션 플레이
+                                manager.updateStatus(to: .getItem)
+
                                 manager.visibleItems[2].isSolid = true
                                 item.removeFromParent()
                                 manager.nearItem = nil
                             }
                             if item.components[ItemComponent.self]?.type == .flashlight {
                                 print("🔦")
+
+                                // 땃쥐 행복해하는 로티 애니메이션 플레이
+                                manager.updateStatus(to: .getItem)
+
                                 manager.visibleItems[3].isSolid = true
                                 manager.setMapCompassAvailable()
                                 item.removeFromParent()
@@ -93,6 +109,10 @@ struct GameView: View {
                         if manager.visibleItems.last?.outlinedImageName == "Map_Outline" {
                             if item.components[ItemComponent.self]?.type == .mapCompass {
                                 print("🗺️")
+
+                                // 땃쥐 행복해하는 로티 애니메이션 플레이
+                                manager.updateStatus(to: .getItem)
+
                                 manager.visibleItems[4].isSolid = true
                                 item.removeFromParent()
                                 manager.nearItem = nil
@@ -121,7 +141,6 @@ struct GameView: View {
                     // 한마디로.. 누적 안되게 초기화
                     lastScale = 1.0
                 }
-
         )
         .allowedDynamicRange(.high)
     }
@@ -144,12 +163,12 @@ struct GameView: View {
         await setupEnvironmentCollisions(on: game, content: content)
 
         if let character,
-            let newspaper = game.findEntity(named: "NewsPaper"),
-            let backpack = game.findEntity(named: "Backpack"),
-            let cheese = game.findEntity(named: "Cheese"),
-            let bottle = game.findEntity(named: "Bottle"),
-            let flashlight = game.findEntity(named: "Flashlight"),
-            let mapCompass = game.findEntity(named: "MapCompass")
+           let newspaper = game.findEntity(named: "NewsPaper"),
+           let backpack = game.findEntity(named: "Backpack"),
+           let cheese = game.findEntity(named: "Cheese"),
+           let bottle = game.findEntity(named: "Bottle"),
+           let flashlight = game.findEntity(named: "Flashlight"),
+           let mapCompass = game.findEntity(named: "MapCompass")
         {
             setupItems(
                 character: character,
@@ -165,7 +184,7 @@ struct GameView: View {
     }
 
     fileprivate struct PlatformerThumbControl: View {
-        let appModel: GameManager
+        let manager: GameManager
         let character: Entity?
         let itemAction: (_ item: Entity, _ camera: Entity) -> Void
 
@@ -174,14 +193,14 @@ struct GameView: View {
 
         var body: some View {
             VStack {
-                if appModel.isFocusedOnItem {
+                if manager.isFocusedOnItem {
                     HStack {
                         Spacer()
 
                         Button(action: {
                             // 뒤로가기 액션 호출
-                            if let item = appModel.nearItem,
-                                let camera = appModel.gameCamera
+                            if let item = manager.nearItem,
+                               let camera = manager.gameCamera
                             {
                                 itemAction(item, camera)
                             }
@@ -198,13 +217,13 @@ struct GameView: View {
 
                 Spacer()
 
-                if !appModel.isFocusedOnItem {
+                if !manager.isFocusedOnItem {
                     HStack(alignment: .bottom) {
                         ThumbStickView(updatingValue: $characterJoystick)
                             .onChange(of: characterJoystick) { _, newValue in
                                 let movementVector: SIMD3<Float> =
                                     [Float(newValue.x), 0, Float(newValue.y)]
-                                    / 10
+                                        / 10
                                 character?
                                     .components[
                                         CharacterMovementComponent.self
@@ -219,11 +238,11 @@ struct GameView: View {
                             )
                             .onChange(of: cameraAngleThumbstick) {
                                 _,
-                                newValue in
+                                    newValue in
                                 let movementVector: SIMD2<Float> =
                                     [Float(newValue.x), Float(-newValue.y)] / 30
 
-                                appModel.gameRoot?.findEntity(named: "camera")?
+                                manager.gameRoot?.findEntity(named: "camera")?
                                     .components[WorldCameraComponent.self]?
                                     .updateWith(
                                         continuousMotion: movementVector
@@ -232,11 +251,11 @@ struct GameView: View {
                             .background(Color.clear)
 
                             HStack {
-                                if appModel.nearItem != nil {
+                                if manager.nearItem != nil {
                                     Button {
-                                        if let item = appModel.nearItem,
-                                            let camera = appModel.gameCamera,
-                                            let character = character
+                                        if let item = manager.nearItem,
+                                           let camera = manager.gameCamera,
+                                           let character = character
                                         {
                                             itemAction(item, camera)
                                             AudioManager.playGetItemSound(
@@ -261,6 +280,7 @@ struct GameView: View {
                                             AudioManager.playJumpSound(
                                                 root: character!
                                             )
+                                            manager.updateStatus(to: .jump)
                                         },
                                         perform: {}
                                     )

--- a/TtouchIsland/Sources/Manager/GameManager.swift
+++ b/TtouchIsland/Sources/Manager/GameManager.swift
@@ -17,6 +17,12 @@ class GameManager {
         gameRoot?.findEntity(named: "camera")
     }
 
+    var currentStatus: CharacterStatus = .common
+
+    func updateStatus(to updatedStatus: CharacterStatus) {
+        currentStatus = updatedStatus
+    }
+
     // MARK: - 아이템 상태 변수
 
     var visibleItems: [StatusItem] = []

--- a/TtouchIsland/Sources/Shared/Component/StatusAnimationIcon.swift
+++ b/TtouchIsland/Sources/Shared/Component/StatusAnimationIcon.swift
@@ -11,15 +11,22 @@ import SwiftUI
 
 struct StatusAnimationIcon: View {
     let file: String
-    let isLoop: Bool = false
+    let isLoop: Bool
+
+    let manager = GameManager.shared
 
     var body: some View {
         LottieView(animation: .named(file))
             .playbackMode(.playing(.fromProgress(0, toProgress: 1, loopMode: isLoop ? .loop : .playOnce)))
+            .animationDidFinish { completed in
+                if completed {
+                    manager.updateStatus(to: .common)
+                }
+            }
             .frame(width: 100, height: 100)
     }
 }
 
 #Preview {
-    StatusAnimationIcon(file: "TtouchMouse_Happy")
+    StatusAnimationIcon(file: "TtouchMouse_Happy", isLoop: true)
 }

--- a/TtouchIsland/Sources/Shared/Component/StatusAnimationItems.swift
+++ b/TtouchIsland/Sources/Shared/Component/StatusAnimationItems.swift
@@ -15,11 +15,10 @@ struct StatusAnimationItems: View {
         ZStack {
             // 배경 사각형
             if !manager.visibleItems.isEmpty {
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(.white, lineWidth: 2)
-                    .fill(.gray)
-                    .opacity(0.5) // 배경 투명도 설정
-                    .frame(width: CGFloat(manager.visibleItems.count) * 54.0 + 20, height: 60)
+                RoundedRectangle(cornerRadius: 15)
+                    .stroke(.white, lineWidth: 1)
+                    .fill(.white.opacity(0.3))
+                    .frame(width: CGFloat(manager.visibleItems.count) * 54.0 + 8, height: 60)
             }
 
             // 아이템들
@@ -27,7 +26,7 @@ struct StatusAnimationItems: View {
                 ForEach(manager.visibleItems, id: \.solidImageName) { item in item }
             }
         }
-        .padding(.top)
+        .padding(.top, 22)
     }
 }
 

--- a/TtouchIsland/Sources/Shared/Enum/CharacterStatus.swift
+++ b/TtouchIsland/Sources/Shared/Enum/CharacterStatus.swift
@@ -1,0 +1,28 @@
+//
+//  CharacterStatus.swift
+//  TtouchIsland
+//
+//  Created by 김현기 on 7/27/25.
+//  Copyright © 2025 Graphicana. All rights reserved.
+//
+
+import Foundation
+
+public enum CharacterStatus: String, CaseIterable {
+    case common = "TtouchMouse_Basic"
+    case jump = "TtouchMouse_Jump"
+    case run = "TtouchMouse_Run"
+    case getItem = "TtouchMouse_Happy"
+    case read = "TtouchMouse_News"
+
+    var filename: String { rawValue }
+
+    var isLoop: Bool {
+        switch self {
+        case .common, .run, .read:
+            return true
+        case .jump, .getItem:
+            return false
+        }
+    }
+}

--- a/TtouchIsland/Sources/UI/GameStatusView.swift
+++ b/TtouchIsland/Sources/UI/GameStatusView.swift
@@ -10,14 +10,14 @@ import Lottie
 import SwiftUI
 
 struct GameStatusView: View {
-    let appModel: GameManager = .shared
+    let manager: GameManager = .shared
 
     var body: some View {
         VStack {
             HStack(alignment: .top, spacing: 0) {
-                StatusAnimationIcon(file: "TtouchMouse_Basic")
+                StatusAnimationIcon(file: manager.currentStatus.filename, isLoop: manager.currentStatus.isLoop)
 
-                if !appModel.isFocusedOnItem {
+                if !manager.isFocusedOnItem {
                     StatusAnimationItems()
                 }
 


### PR DESCRIPTION
### 📕 Issue Number

#63 진행 중 (완료 안 됌)


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 일반(대기, 걷기) & 뛰기 & 아이템줍기 & 신문읽기 에 따른 로티 애니메이션 적용
- [x] 달리기 로티 애니메이션은 추후에 달리기 버튼 적용할 때 구현 예정

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 각 상태에 맞게 로티 애니메이션을 불러오는 과정
```swift
public enum CharacterStatus: String, CaseIterable {
    case common = "TtouchMouse_Basic"
    case jump = "TtouchMouse_Jump"
    case run = "TtouchMouse_Run"
    case getItem = "TtouchMouse_Happy"
    case read = "TtouchMouse_News"

    var filename: String { rawValue }

    var isLoop: Bool {
        switch self {
        case .common, .run, .read:
            return true
        case .jump, .getItem:
            return false
        }
    }
}

struct StatusAnimationIcon: View {
    let file: String
    let isLoop: Bool = false
    let isLoop: Bool

    let manager = GameManager.shared

    var body: some View {
        LottieView(animation: .named(file))
            .playbackMode(.playing(.fromProgress(0, toProgress: 1, loopMode: isLoop ? .loop : .playOnce)))
            .animationDidFinish { completed in
                if completed {
                    manager.updateStatus(to: .common)
                }
            }
            .frame(width: 100, height: 100)
    }
}
```
CharacterStatus Enum을 만들어서 각 상태에 맞는 파일경로와 loop할지 말지를 설정해서
커스텀로티뷰를 좀 수정해서 애니메이션을 각 상태에 적합한 상태로 재생시키도록 설정하였습니다.

### 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

https://github.com/user-attachments/assets/c5fdd42b-d4fd-459e-911e-fcccb034386e


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>


<br/><br/>
